### PR TITLE
Use ReactiveList in Conductor.Collection

### DIFF
--- a/src/Caliburn.Micro.ReactiveUI/ReactiveConductorWithCollectionAllActive.cs
+++ b/src/Caliburn.Micro.ReactiveUI/ReactiveConductorWithCollectionAllActive.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Reflection;
-using System.Text;
+using ReactiveUI;
 
 namespace Caliburn.Micro.ReactiveUI
 {
@@ -19,7 +19,7 @@ namespace Caliburn.Micro.ReactiveUI
             /// </summary>
             public class AllActive : ReactiveConductorBase<T>
             {
-                readonly BindableCollection<T> items = new BindableCollection<T>();
+                readonly ReactiveList<T> items = new ReactiveList<T>();
                 readonly bool openPublicItems;
 
                 /// <summary>
@@ -61,7 +61,7 @@ namespace Caliburn.Micro.ReactiveUI
                 /// <summary>
                 /// Gets the items that are currently being conducted.
                 /// </summary>
-                public IObservableCollection<T> Items
+                public IReactiveList<T> Items
                 {
                     get { return items; }
                 }
@@ -98,7 +98,7 @@ namespace Caliburn.Micro.ReactiveUI
                         if (!canClose && closable.Any())
                         {
                             closable.OfType<IDeactivate>().Apply(x => x.Deactivate(true));
-                            items.RemoveRange(closable);
+                            items.RemoveAll(closable);
                         }
 
                         callback(canClose);

--- a/src/Caliburn.Micro.ReactiveUI/ReactiveConductorWithCollectionOneActive.cs
+++ b/src/Caliburn.Micro.ReactiveUI/ReactiveConductorWithCollectionOneActive.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using ReactiveUI;
 
 namespace Caliburn.Micro.ReactiveUI
 {
@@ -17,7 +18,7 @@ namespace Caliburn.Micro.ReactiveUI
             /// </summary>
             public class OneActive : ReactiveConductorBaseWithActiveItem<T>
             {
-                readonly BindableCollection<T> items = new BindableCollection<T>();
+                readonly ReactiveList<T> items = new ReactiveList<T>();
 
                 /// <summary>
                 /// Initializes a new instance of the <see cref="Conductor&lt;T&gt;.Collection.OneActive"/> class.
@@ -48,7 +49,7 @@ namespace Caliburn.Micro.ReactiveUI
                 /// <summary>
                 /// Gets the items that are currently being conducted.
                 /// </summary>
-                public IObservableCollection<T> Items
+                public IReactiveList<T> Items
                 {
                     get { return items; }
                 }
@@ -182,7 +183,7 @@ namespace Caliburn.Micro.ReactiveUI
                             }
 
                             closable.OfType<IDeactivate>().Apply(x => x.Deactivate(true));
-                            items.RemoveRange(closable);
+                            items.RemoveAll(closable);
                         }
 
                         callback(canClose);


### PR DESCRIPTION
Shouldn't the conductors' list of items be a reactive list if we are merging the best of both worlds?

**UPDATE:**
This would be a breaking change as it changes the API of the public Items list.

``` c#
public IReactiveList<T> Items
{
    get { return items; }
}
```

We could create a subclass of `ReactiveList` that implements `Caliburn.Micro.IObservableCollection`.
